### PR TITLE
Add exception for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://twitter.com/davecheney/status/871939730761547776
 
 ### Exceptions
 
-There are **very** few exceptions to the global variable rule. This will will ignore the following patterns:
+There are **very** few exceptions to the global variable rule. This tool will ignore the following patterns:
  * Variables with an "Err" prefix
  * Variables named _
  * Variables named Version to support [compile time version setting](https://medium.com/@joshroppo/setting-go-1-5-variables-at-compile-time-for-versioning-5b30a965d33e)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ Global variables are an input to functions that is not visible in the functions 
 https://peter.bourgon.org/blog/2017/06/09/theory-of-modern-go.html
 https://twitter.com/davecheney/status/871939730761547776
 
+### Exceptions
+
+There are **very** few exceptions to the global variable rule. This will will ignore the following patterns:
+ * Variables with an "Err" prefix
+ * Variables named _
+ * Variables named Version to support [compile time version setting](https://medium.com/@joshroppo/setting-go-1-5-variables-at-compile-time-for-versioning-5b30a965d33e)
+
 ## Install
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://twitter.com/davecheney/status/871939730761547776
 There are **very** few exceptions to the global variable rule. This tool will ignore the following patterns:
  * Variables with an "Err" prefix
  * Variables named _
- * Variables named Version to support [compile time version setting](https://medium.com/@joshroppo/setting-go-1-5-variables-at-compile-time-for-versioning-5b30a965d33e)
+ * Variables named "version" to support [compile time version setting](https://medium.com/@joshroppo/setting-go-1-5-variables-at-compile-time-for-versioning-5b30a965d33e)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ https://twitter.com/davecheney/status/871939730761547776
 
 ### Exceptions
 
-There are **very** few exceptions to the global variable rule. This tool will ignore the following patterns:
- * Variables with an "Err" prefix
- * Variables named _
- * Variables named "version" to support [compile time version setting](https://medium.com/@joshroppo/setting-go-1-5-variables-at-compile-time-for-versioning-5b30a965d33e)
+There are very few exceptions to the global variable rule. This tool will ignore the following patterns:
+ * Variables with an `Err` prefix
+ * Variables named `_`
+ * Variables named `version`
 
 ## Install
 

--- a/check_no_globals.go
+++ b/check_no_globals.go
@@ -11,7 +11,7 @@ import (
 )
 
 func isWhitelisted(i *ast.Ident) bool {
-	return i.Name == "_" || looksLikeError(i)
+	return i.Name == "_" || i.Name == "Version" || looksLikeError(i)
 }
 
 // looksLikeError returns true if the AST identifier starts

--- a/check_no_globals.go
+++ b/check_no_globals.go
@@ -11,7 +11,7 @@ import (
 )
 
 func isWhitelisted(i *ast.Ident) bool {
-	return i.Name == "_" || i.Name == "Version" || looksLikeError(i)
+	return i.Name == "_" || i.Name == "version" || looksLikeError(i)
 }
 
 // looksLikeError returns true if the AST identifier starts

--- a/check_no_globals_test.go
+++ b/check_no_globals_test.go
@@ -108,7 +108,8 @@ func TestCheckNoGlobals(t *testing.T) {
 		{
 			path: "testdata/9",
 			wantMessages: []string{
-				"testdata/9/code.go:4 Version22 is a global variable",
+				"testdata/9/code.go:3 Version is a global variable",
+				"testdata/9/code.go:4 version22 is a global variable",
 			},
 		},
 		{
@@ -141,7 +142,8 @@ func TestCheckNoGlobals(t *testing.T) {
 				"testdata/8/code.go:20 myVarError is a global variable",
 				"testdata/8/code.go:21 customErr is a global variable",
 				"testdata/8/code.go:30 declaredErr is a global variable",
-				"testdata/9/code.go:4 Version22 is a global variable",
+				"testdata/9/code.go:3 Version is a global variable",
+				"testdata/9/code.go:4 version22 is a global variable",
 			},
 		},
 	}

--- a/check_no_globals_test.go
+++ b/check_no_globals_test.go
@@ -106,6 +106,12 @@ func TestCheckNoGlobals(t *testing.T) {
 			},
 		},
 		{
+			path: "testdata/9",
+			wantMessages: []string{
+				"testdata/9/code.go:4 Version22 is a global variable",
+			},
+		},
+		{
 			path:         ".",
 			wantMessages: nil,
 		},
@@ -135,6 +141,7 @@ func TestCheckNoGlobals(t *testing.T) {
 				"testdata/8/code.go:20 myVarError is a global variable",
 				"testdata/8/code.go:21 customErr is a global variable",
 				"testdata/8/code.go:30 declaredErr is a global variable",
+				"testdata/9/code.go:4 Version22 is a global variable",
 			},
 		},
 	}

--- a/testdata/9/code.go
+++ b/testdata/9/code.go
@@ -1,0 +1,4 @@
+package code
+
+var Version string
+var Version22 string

--- a/testdata/9/code.go
+++ b/testdata/9/code.go
@@ -1,4 +1,5 @@
 package code
 
 var Version string
-var Version22 string
+var version22 string
+var version string


### PR DESCRIPTION
Current best practice for setting the version of a Go executable requires a global variable. This change adds a narrow exception for variables name Version exactly. It also adds tests to verify that and updates to README to explicitly state the permitted exceptions.