### PR TITLE
Don't allow `BasicLit` as error, suggest to make as `const`

### DIFF
--- a/checknoglobals/check_no_globals_test.go
+++ b/checknoglobals/check_no_globals_test.go
@@ -16,7 +16,7 @@ func TestCheckNoGlobals(t *testing.T) {
 	analyzer := Analyzer()
 	analyzer.Flags = *flags
 
-	for i := 0; i <= 11; i++ {
+	for i := 0; i <= 12; i++ {
 		dir := strconv.Itoa(i)
 		t.Run(dir, func(t *testing.T) {
 			analysistest.Run(t, testdata, analyzer, dir)

--- a/checknoglobals/testdata/src/10/code.go
+++ b/checknoglobals/testdata/src/10/code.go
@@ -12,8 +12,8 @@ var myVar = 1 // want "myVar is a global variable"
 // ErrNotFound is an error and should be OK.
 var ErrNotFound = errors.New("this is error")
 
-// ErrIsNotErr is an error and should be OK.
-var ErrIsNotErr = 1
+// ErrIsNotErr is not an error and can be a const.
+var ErrIsNotErr = 1 // want "ErrIsNotErr is a global variable, should be a const"
 
 // IsOnlyDigitsRe is a global regexp that should be OK.
 var IsOnlyDigitsRe = regexp.MustCompile(`^\d+$`)

--- a/checknoglobals/testdata/src/12/code.go
+++ b/checknoglobals/testdata/src/12/code.go
@@ -1,0 +1,12 @@
+package code
+
+import "errors"
+
+// myVar is just a bad named global var.
+var myVar = 1 // want "myVar is a global variable"
+
+// ErrNotFound is an error and should be OK.
+var ErrNotFound = errors.New("this is error")
+
+// ErrIsNotErr is an error and should be OK.
+var ErrIsNotErr = 1 // want "ErrIsNotErr is a global variable, should be a const"

--- a/checknoglobals/testdata/src/12/code.go
+++ b/checknoglobals/testdata/src/12/code.go
@@ -3,7 +3,7 @@ package code
 import "errors"
 
 // myVar is just a bad named global var.
-var myVar = 1 // want "myVar is a global variable"
+var myVar = 1 // want "myVar is a global variable, should be a const"
 
 // ErrNotFound is an error and should be OK.
 var ErrNotFound = errors.New("this is error")

--- a/checknoglobals/testdata/src/7/code.go
+++ b/checknoglobals/testdata/src/7/code.go
@@ -7,11 +7,10 @@ import (
 // Those are not errors
 var myVar = 1 // want "myVar is a global variable"
 
-// Those are fake errors which are currently not detected
-// because they start with 'err' or 'Err' and we don't
-// check if such a variable implements the error interface.
-var errFakeErrorUnexported = 1
-var ErrFakeErrorExported = 1
+// Those are fake errors which are not allowed since they are basic literals and
+// can be converted o const.
+var errFakeErrorUnexported = 1 // want "errFakeErrorUnexported is a global variable, should be a const"
+var ErrFakeErrorExported = 1   // want "ErrFakeErrorExported is a global variable, should be a const"
 
 // Those errors are not named correctly
 var myErrVar = errors.New("myErrVar")    // want "myErrVar is a global variable"

--- a/checknoglobals/testdata/src/8/code.go
+++ b/checknoglobals/testdata/src/8/code.go
@@ -8,11 +8,10 @@ var (
 	// Those are not errors
 	myVar = 1 // want "myVar is a global variable"
 
-	// Those are fake errors which are currently not detected
-	// because they start with 'err' or 'Err' and we don't
-	// check if such a variable implements the error interface.
-	errFakeErrorUnexported = 1
-	ErrFakeErrorExported   = 1
+	// Those are fake errors which are not allowed since they are basic literals and
+	// can be converted o const.
+	errFakeErrorUnexported = 1 // want "errFakeErrorUnexported is a global variable, should be a const"
+	ErrFakeErrorExported   = 1 // want "ErrFakeErrorExported is a global variable, should be a const"
 
 	// Those errors are not named correctly
 	myErrVar   = errors.New("myErrVar")   // want "myErrVar is a global variable"


### PR DESCRIPTION
~~This PR extends #12 which will only allow global error variables prefixed with `Err` if they're assigned from `fmt.Errorf` or `errors.New`.~~

~~This branch is based on `whitelisted-selectors` which makes the diff towards `master` looks bigger than it is. When(/if) #12 is merged I will rebase this branch to visualise the diff better.~~

~~This PR is a result of https://github.com/leighmcculloch/gochecknoglobals/pull/12#issuecomment-697123787 where I got asked to limit the first PR to only add support for `regexp.MustCompile` and not touch error handling. I still think this PR is valid since there's a lot of missed errors not caught and since go 1.14 we shouldn't use custom error types if possible to avoid.~~

---

~~Only allow global error variables if the're assigned from `fmt.Errorf` and `errors.New`. Relates to #5~~

~~I know this is probably very opinionated but I'll just leave it here to marinate and use for discussion.~~

---

Don't allow global vars, even if they're prefixed with `err` or `Err`, to be assigned to a `*ast.BasicLit` since these can be converted to `const`  instead.