### PR TITLE
Remove codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,4 @@ go:
 go_import_path: 4d63.com/gochecknoglobals
 
 script:
-  - go test -coverprofile=coverage.txt
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - go test -cover

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # gochecknoglobals
 
 [![Build Status](https://img.shields.io/travis/leighmcculloch/gochecknoglobals.svg)](https://travis-ci.org/leighmcculloch/gochecknoglobals)
-[![Codecov](https://img.shields.io/codecov/c/github/leighmcculloch/gochecknoglobals.svg)](https://codecov.io/gh/leighmcculloch/gochecknoglobals)
 [![Go Report Card](https://goreportcard.com/badge/github.com/leighmcculloch/gochecknoglobals)](https://goreportcard.com/report/github.com/leighmcculloch/gochecknoglobals)
 
 Check that no globals are present in Go code.


### PR DESCRIPTION
### What
Remove codecov code coverage tool.

### Why
They were hacked and exploited, and tbh I'm not really using it because the Go built in coverage support is pretty amazing as it is.