### PR TITLE
Simplify benchmark

### DIFF
--- a/checknoglobals/check_no_globals_test.go
+++ b/checknoglobals/check_no_globals_test.go
@@ -29,8 +29,21 @@ func BenchmarkRun(b *testing.B) {
 	flags := flag.NewFlagSet("", flag.ExitOnError)
 	flags.Bool("t", true, "")
 	analyzer.Flags = *flags
-	testdata := analysistest.TestData()
-	results := analysistest.Run(b, testdata, analyzer, "./...")
+	dir, cleanup, err := analysistest.WriteFiles(map[string]string{
+		"file.go": `package code
+		import "errors"
+		var global = "" // want "global is a global variable"
+		var ErrVar = errors.New("myErrVar")
+		var myErrVar = errors.New("myErrVar") // want "myErrVar is a global variable"
+		var errCustom = customError{}
+		type customError struct {}
+		func (customError) Error() string { return "custom error" }`,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer cleanup()
+	results := analysistest.Run(b, dir, analyzer, "./...")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, r := range results {


### PR DESCRIPTION
### What
Simplify benchmark to use a smaller set of well defined test cases instead of just all the tests cases.

### Why
When we make changes to gochecknoglobals it would be ideal if the benchmark doesn't need to change so we can compare from one to the next. Testdata always changes, so it isn't a great benchmark input.