### PR TITLE
Remove the -t flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ gochecknoglobals [package]
 gochecknoglobals ./...
 ```
 
-By default, test files will not be checked but can be included by adding the
-`-t` flag.
+By default, test files are checked but can be excluded by adding the
+`-test=false` flag.
 
 ```
-gochecknoglobals -t [package]
+gochecknoglobals -test=false [package]
 ```

--- a/checknoglobals/check_no_globals.go
+++ b/checknoglobals/check_no_globals.go
@@ -1,7 +1,6 @@
 package checknoglobals
 
 import (
-	"flag"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -37,16 +36,8 @@ func Analyzer() *analysis.Analyzer {
 		Name:             "gochecknoglobals",
 		Doc:              Doc,
 		Run:              checkNoGlobals,
-		Flags:            flags(),
 		RunDespiteErrors: true,
 	}
-}
-
-func flags() flag.FlagSet {
-	flags := flag.NewFlagSet("", flag.ExitOnError)
-	flags.Bool("t", false, "Include tests")
-
-	return *flags
 }
 
 func isAllowed(cm ast.CommentMap, v ast.Node, ti *types.Info) bool {
@@ -138,14 +129,9 @@ func hasEmbedComment(cm ast.CommentMap, n ast.Node) bool {
 }
 
 func checkNoGlobals(pass *analysis.Pass) (interface{}, error) {
-	includeTests := pass.Analyzer.Flags.Lookup("t").Value.(flag.Getter).Get().(bool)
-
 	for _, file := range pass.Files {
 		filename := pass.Fset.Position(file.Pos()).Filename
 		if !strings.HasSuffix(filename, ".go") {
-			continue
-		}
-		if !includeTests && strings.HasSuffix(filename, "_test.go") {
 			continue
 		}
 


### PR DESCRIPTION
### What
Remove the -t flag.

### Why
Newer versions of the singlechecker, which is the library that creates the CLI interface, have a `-test=[true|false]` option. It's confusing that the CLI interface now has `-t` and `-test`.

This change is somewhat problematic to make, because the two flags work contrary to each other. The CLI currently has tests disabled and `-t` enables them. However, the `-test` flag works in reverse. Singlechecker assumes tests are enabled by default and `-test=false` disables them.

Another reason we should remove the `-t` flag is because it doesn't interact well with the multichecker setup where multiple analyzers are combined together. Analyzers expect tests to be enabled and to let the analysis framework filter tests if flagged.
