### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are very few exceptions to the global variable rule. This tool will ignore
 ## Install
 
 ```
-go get 4d63.com/gochecknoglobals
+go install 4d63.com/gochecknoglobals@latest
 ```
 
 ## Usage


### PR DESCRIPTION
### What
Change install instructions to use go install.

### Why
The install instructions are out-of-date and use go get, which no longer works for installing binaries.